### PR TITLE
fix: gradle-tooling-api dependency is added to the target project

### DIFF
--- a/src/it/gradle-tooling-api/invoker.properties
+++ b/src/it/gradle-tooling-api/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals.1=verify
+invoker.goals.1=verify dependency:tree

--- a/src/it/gradle-tooling-api/verify.groovy
+++ b/src/it/gradle-tooling-api/verify.groovy
@@ -1,5 +1,6 @@
 import java.util.jar.JarFile
 
+// Dependency is downloaded to the local Maven repository
 def gradleToolingApiJar = new File(projectBuildDirectory,
     "local-repo/org/gradle/gradle-tooling-api/${versionGradle8}/gradle-tooling-api-${versionGradle8}.jar")
 assert gradleToolingApiJar.exists()
@@ -16,3 +17,7 @@ jar.entries().each {
 }
 assert containsManifest
 assert containsGradleApi
+
+// Project contains dependency to gradle-tooling-api (dependency:tree output)
+def buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('[INFO] +- org.gradle:gradle-tooling-api:jar:')

--- a/src/main/java/com/marcnuri/plugins/gradle/api/GradleApi.java
+++ b/src/main/java/com/marcnuri/plugins/gradle/api/GradleApi.java
@@ -50,7 +50,9 @@ public class GradleApi implements Callable<Collection<String>> {
       downloadDistribution();
       downloadGradleToolingApi();
     }
-    return extract();
+    final Set<String> artifactIds = extract();
+    artifactIds.add(GRADLE_TOOLING_API_ARTIFACT_ID);
+    return artifactIds;
   }
 
   private void downloadDistribution() {


### PR DESCRIPTION
Fixes https://github.com/fabric8io/kubernetes-client/issues/6163